### PR TITLE
Adding more handlers for trigger nodes.

### DIFF
--- a/jenkins-xml-to-jobdsl.rb
+++ b/jenkins-xml-to-jobdsl.rb
@@ -663,6 +663,8 @@ class ExtendedEmailNodeHandler < Struct.new(:node)
             pp e
           end
         end
+      when 'failureCount'
+        #unsupported
       else
         pp k
       end
@@ -692,12 +694,36 @@ class ExtendedEmailNodeHandler < Struct.new(:node)
         puts " " * currentDepth + "triggers {"
         i.elements.each do |j|
           case j.name
+          when 'hudson.plugins.emailext.plugins.trigger.FixedTrigger'
+            puts " " * (currentDepth + indent) + "fixed {"
+            print_trigger_block(j, currentDepth, indent)
+            puts " " * (currentDepth + indent) + "}"
+          when 'hudson.plugins.emailext.plugins.trigger.FirstFailureTrigger'
+            puts " " * (currentDepth + indent) + "firstFailure {"
+            print_trigger_block(j, currentDepth, indent)
+            puts " " * (currentDepth + indent) + "}"
           when 'hudson.plugins.emailext.plugins.trigger.FailureTrigger'
             puts " " * (currentDepth + indent) + "failure {"
             print_trigger_block(j, currentDepth, indent)
             puts " " * (currentDepth + indent) + "}"
           when 'hudson.plugins.emailext.plugins.trigger.SuccessTrigger'
             puts " " * (currentDepth + indent) + "success {"
+            print_trigger_block(j, currentDepth, indent)
+            puts " " * (currentDepth + indent) + "}"
+          when 'hudson.plugins.emailext.plugins.trigger.AlwaysTrigger'
+            puts " " * (currentDepth + indent) + "always {"
+            print_trigger_block(j, currentDepth, indent)
+            puts " " * (currentDepth + indent) + "}"
+          when 'hudson.plugins.emailext.plugins.trigger.StillFailingTrigger'
+            puts " " * (currentDepth + indent) + "stillFailing {"
+            print_trigger_block(j, currentDepth, indent)
+            puts " " * (currentDepth + indent) + "}"
+          when 'hudson.plugins.emailext.plugins.trigger.StatusChangedTrigger'
+            puts " " * (currentDepth + indent) + "statusChanged {"
+            print_trigger_block(j, currentDepth, indent)
+            puts " " * (currentDepth + indent) + "}"
+          when 'hudson.plugins.emailext.plugins.trigger.UnstableTrigger'
+            puts " " * (currentDepth + indent) + "unstable {"
             print_trigger_block(j, currentDepth, indent)
             puts " " * (currentDepth + indent) + "}"
           else


### PR DESCRIPTION
There are more but don't have any test xml to verify translation with
besides the ones added in this commit.

Full list of DSL blocks:
https://jenkinsci.github.io/job-dsl-plugin/#path/javaposse.jobdsl.dsl.helpers.publisher.PublisherContext.extendedEmail-triggers