### PR TITLE
issue-44 - update gradle version and install method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,21 @@ RUN true \
 
 RUN true \
  && apt-get update \
- && apt-get install -qy --no-install-recommends openjdk-8-jdk openjdk-8-jre gradle \
+ && apt-get install -qy --no-install-recommends openjdk-8-jdk openjdk-8-jre \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* 
+
+RUN true \
+ && apt-get update \
+ && apt-get install -qy --no-install-recommends curl\
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+ 
+RUN curl -sL https://services.gradle.org/distributions/gradle-4.6-bin.zip -o gradle-4.6.zip \
+ && unzip -d /usr/share gradle-4.6.zip \
+ && ln -s /usr/share/gradle-4.6/bin/gradle /usr/bin/gradle \
+ && gradle --version \
+ && rm gradle-4.6.zip
 
 RUN true \
  && apt-get update \


### PR DESCRIPTION
Update how gradle is installed so that newer version 4.6 can be installed, allowing docker build to succeed.

Related issue(s) 
* #44 - cannot build job-dsl-plugin 

